### PR TITLE
Update gitattributes to prevent changing line endings on .bin files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # force git to convert line endings
 # crlf line endings break many things
 * text eol=lf
+*.bin -text


### PR DESCRIPTION
.bin file extension was used for opening book and the auto line ending conversion broke it. This probably applies to other languages as well.